### PR TITLE
Adds 'edit this page' link to each page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,6 +11,7 @@ module.exports = {
         contentPath: 'notes',
         basePath: '/',
         showThemeInfo: false,
+        gitRepoContentPath: 'https://github.com/dropcat13/codenotes/tree/dev/notes/',
         showDescriptionInSidebar: true,
       },
     },


### PR DESCRIPTION
Users can now click on a link that says 'edit this page' right on each page (including you). It will bring them straight to the relevant Github markdown file.